### PR TITLE
Pass auth credentials using env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
 [Blade](https://github.com/javan/blade) plugin for [Sauce Labs](https://saucelabs.com/)
+
+## Configuration
+
+### Authenticate with Sauce Labs
+
+Set the `SAUCE_USERNAME` and `SAUCE_API_KEY` environment variables to authenticate with Sauce Labs.
+
+All CI tools provide a way to set environment variables for a test run. For non-CI test runs, set the environment variables in your shell or in your test runner script.
+
+### Pick the browsers to run against
+
+Rather than exhaustively list every permutation of devices, operating systems,
+and browsers, we use a shorthand to match all the platforms we target.
+
+Full example:
+```yaml
+plugins:
+  sauce_labs:
+    browsers:
+      # Internet Explorer 11 on every device and operating system it supports.
+      IE: 11
+
+      # Latest two Chrome releases on all Mac and Windows platforms:
+      Google Chrome:
+        os: Mac, Windows
+        version: -2
+
+      # Latest two Firefox releases on every platform:
+      Firefox:
+        version: -2
+
+      # Latest Safari release on every Mac platform (OS X 10.x):
+      Safari:
+        platform: Mac
+        version: -1
+
+      # Latest two Edge releases on every platform:
+      Microsoft Edge:
+        version: -2
+
+      # Specific iOS Mobile Safari versions:
+      iPhone:
+        version: [9.2, 8.4]
+
+      # Mobile-specific browser:
+      Motorola Droid 4 Emulator:
+        version: [5.1, 4.4]
+```
+
+See Sauce Labs' [Platform Configurator](https://wiki.saucelabs.com/display/DOCS/Platform+Configurator) for an exhaustive list of supported devices, operating systems, and browsers.

--- a/lib/blade/sauce_labs_plugin.rb
+++ b/lib/blade/sauce_labs_plugin.rb
@@ -48,11 +48,11 @@ module Blade::SauceLabsPlugin
   end
 
   def username
-    config.username || ENV["SAUCE_USERNAME"]
+    ENV["SAUCE_USERNAME"] || config.username
   end
 
   def access_key
-    config.access_key || ENV["SAUCE_ACCESS_KEY"]
+    ENV["SAUCE_ACCESS_KEY"] || config.access_key
   end
 
   def debug(message)

--- a/lib/blade/sauce_labs_plugin/tunnel.rb
+++ b/lib/blade/sauce_labs_plugin/tunnel.rb
@@ -36,6 +36,7 @@ module Blade::SauceLabsPlugin::Tunnel
       ChildProcess.build(tunnel_command, *tunnel_args).tap do |process|
         process.leader = true
         process.io.inherit! if debug?
+        process.environment.merge! tunnel_env
         process.start
         debug process.inspect
       end
@@ -46,7 +47,11 @@ module Blade::SauceLabsPlugin::Tunnel
     end
 
     def tunnel_args
-      ["--user", username, "--api-key", access_key, "--tunnel-identifier", identifier, "--readyfile", ready_file_path]
+      ["--tunnel-identifier", identifier, "--readyfile", ready_file_path]
+    end
+
+    def tunnel_env
+      { "SAUCE_USERNAME" => username, "SAUCE_API_KEY" => access_key }
     end
 
     def ready_file_path


### PR DESCRIPTION
Pass Sauce credentials to child process using env vars so they don't show up on the command line.

Adds some docs on how to authenticate and configure.
